### PR TITLE
Accelerated Gradient Descent: incorrect sign in upper bound gap fix

### DIFF
--- a/agao21_script/lecture3_mod.tex
+++ b/agao21_script/lecture3_mod.tex
@@ -1007,7 +1007,7 @@ rate function:
        \right)
        & \tag*{First term controlled by Equation~\eqref{eq:agdub}.}
   \\
-  &+
+  &-
      A_{i}
     \ip{\grad f(\xx_{i+1}), \yy_{i} - \xx_{i+1}  }
     \tag*{Second term bounded by Theorem~\ref{thm:convexlb}.}


### PR DESCRIPTION
In the lecture, you wrote minus at first, then someone pointed out that there was a plus in the script, so you changed it, but the minus seems to be correct. This would also correspond with the result at the bottom of page 38.